### PR TITLE
image_width used twice and image_height ignored fixed.

### DIFF
--- a/inc/image_bytes.h
+++ b/inc/image_bytes.h
@@ -58,7 +58,7 @@ struct image_bytes
     
     for (unsigned int x = 0; x < image_width; ++x)
     {
-      for (unsigned int y = 0; y < image_width; ++y)
+      for (unsigned int y = 0; y < image_height; ++y)
       {
         auto curr_x = x + x_start;
         auto curr_y = y + y_start;


### PR DESCRIPTION
There was a typo such that the width and height iterator of the input image_bytes was between the range of 0 and image_width. The height iterator now iterates between 0 and image_height as it should.